### PR TITLE
minor fix to header

### DIFF
--- a/Frontend/src/components/Header.js
+++ b/Frontend/src/components/Header.js
@@ -100,7 +100,8 @@ export default function Header() {
                                 <Translate>Log out</Translate>
                             </button>
                         </div>
-                    ) : (
+                    ) : (<div className="flex items-center gap-4">
+                        <LanguageSwitch />
                         <a
                             href="/login"
                             className="text-sm font-semibold leading-6 text-white bg-teal-600 hover:bg-teal-700 px-4 py-2 rounded-md transition duration-150 ease-in-out flex items-center"
@@ -108,6 +109,7 @@ export default function Header() {
                             <UserCircleIcon className="h-5 w-5 mr-2" />
                             <Translate>Login</Translate>
                         </a>
+                        </div>
                     )}
             </div>
         </nav>


### PR DESCRIPTION
Translation Icon now present when no user is logged in

![image](https://github.com/user-attachments/assets/a10d2786-dc42-4d78-a148-5c913f0fd675)
